### PR TITLE
Fix authorization rust example

### DIFF
--- a/docs/src/usage/rust.md
+++ b/docs/src/usage/rust.md
@@ -69,14 +69,10 @@ fn authorize(token: &Biscuit) -> Result<(), error::Token> {
         .allow_all()
         .build(token)?;
 
-    // link the token to the authorizer
-    let result = authorizer.authorize(token);
-
     // store the authorization context
     println!("{}", authorizer.to_base64_snapshot()?);
 
-    let _ = result?;
-    Ok(())
+    authorizer.authorize()
 }
 ```
 


### PR DESCRIPTION
There was an issue in the example, spotted by @remibardon

Also, now that the `Authorizer` creation is separated from the actual `authorize()` call, taking a snapshot is easier.